### PR TITLE
Feat: Decimals when module is token

### DIFF
--- a/src/utils/parseInputs/utils.ts
+++ b/src/utils/parseInputs/utils.ts
@@ -108,6 +108,13 @@ export const decimals = async ({
           functionName: 'decimals',
         })
         break
+      case 'exact':
+        decimals = <number>await readContract({
+          address: contract.address,
+          abi: DECIMALS_ABI,
+          functionName: name,
+        })
+        break
     }
   }
   if (!decimals) throw new Error('No decimals provided')


### PR DESCRIPTION
This covers the case where the module itself is a token, e.g. the RebasingFundingManager. The tag in that example would look as follows:

`decimals:external:exact:decimals`