### PR TITLE
fix(wip): empty optional schemas, test types/cases, tuple deployments

### DIFF
--- a/src/getDeploy/getRpcInteractions.ts
+++ b/src/getDeploy/getRpcInteractions.ts
@@ -23,13 +23,8 @@ const getEncodedArgs = async (
   userModuleArg: UserModuleArg
 ) => {
   const formattedInputs = formatParameters(configData)
-  // TODO: Handle undefined userModuleArg
-  const args = getValues(userModuleArg)
 
-  // TODO: pass formattedInputs and args to parseInputs
-  // challenge: parseInputs returns a flat array but viem's
-  // encodeAbiParameters expects a different format:
-  // https://viem.sh/docs/abi/encodeAbiParameters.html#simple-struct
+  const args = userModuleArg ? getValues(userModuleArg) : '0x00'
 
   // MG NOTE: Parse inputs respects the array order and struct structure
 

--- a/src/getDeploy/types/args/static.ts
+++ b/src/getDeploy/types/args/static.ts
@@ -7,7 +7,6 @@ export type Metadata = {
 
 export type EncodedArgs = {
   configData: `0x${string}`
-  dependencyData: `0x${string}`
 }
 
 export type OrchestratorArgs = {

--- a/src/getDeploy/types/schema.ts
+++ b/src/getDeploy/types/schema.ts
@@ -2,7 +2,7 @@ import { ModuleName } from '@inverter-network/abis'
 import { OrchestratorInputs } from './generic'
 import { FomrattedDeploymentParameters } from './parameter'
 import { RequestedModules } from './requested'
-import { OmitNever } from '../../types'
+import { EmptyObjectToNever, OmitNever } from '../../types'
 import { Simplify } from 'type-fest-4'
 
 export type ModuleSchema<N extends ModuleName = ModuleName> = {
@@ -29,6 +29,6 @@ export type DeploySchema<T extends RequestedModules = RequestedModules> =
       paymentProcessor: ModuleSchema<T['paymentProcessor']>
       fundingManager: ModuleSchema<T['fundingManager']>
       authorizer: ModuleSchema<T['authorizer']>
-      optionalModules: OptionalModules<T['optionalModules']>
+      optionalModules: EmptyObjectToNever<OptionalModules<T['optionalModules']>>
     }>
   >

--- a/src/types/utils/parameter/index.ts
+++ b/src/types/utils/parameter/index.ts
@@ -43,22 +43,24 @@ type GetJsType<
 // Format the AbiParameter type from solidity to typscript type and-
 // add the description and tag to the parameter
 export type FormatParameter<P> = P extends ExtendedAbiParameter
-  ? P extends { type: TupleType; components: infer Components }
-    ? {
-        name: P['name']
-        type: P['type']
-        description: P['description']
-        components: FormatParameters<Components>
-      }
-    : Simplify<
-        OmitNever<{
-          name: P['name']
-          type: P['type']
-          description: IfUnknown<P['description'], never, P['description']>
-          jsType: GetJsType<P['type'], P['tags']>
-          tags: IfUnknown<P['tags'], never, P['tags']>
-        }>
+  ? Simplify<
+      OmitNever<
+        P extends { type: TupleType; components: infer Components }
+          ? {
+              name: P['name']
+              type: P['type']
+              description: IfUnknown<P['description'], never, P['description']>
+              components: FormatParameters<Components>
+            }
+          : {
+              name: P['name']
+              type: P['type']
+              description: IfUnknown<P['description'], never, P['description']>
+              jsType: GetJsType<P['type'], P['tags']>
+              tags: IfUnknown<P['tags'], never, P['tags']>
+            }
       >
+    >
   : never
 
 // Itterate over the parameters and format them

--- a/src/utils/parseInputs/utils.ts
+++ b/src/utils/parseInputs/utils.ts
@@ -75,7 +75,6 @@ export const decimals = async ({
   publicClient: PublicClient
   contract?: any
 }) => {
-  console.log(decimalsTag)
   let decimals = extras?.decimals
 
   const [, source, location, name] = decimalsTag?.split(':')

--- a/src/utils/parseInputs/utils.ts
+++ b/src/utils/parseInputs/utils.ts
@@ -84,11 +84,14 @@ export const decimals = async ({
     switch (location) {
       case 'exact':
         decimals =
+          // check if the value is contained by a non-tuple arg search it based on the index that is has in `inputs`
           args[
             inputs.findIndex((input) => {
               return input.name === name
             })
-          ]
+            // or if there is a tuple arg that contains a parameter with `name`which would provide the decimals
+          ] || args.find((arg) => !!arg[name])[name]
+
         break
       case 'indirect':
         const address = args[inputs.findIndex((input) => input.name === name)]
@@ -122,6 +125,7 @@ export const decimals = async ({
         break
     }
   }
+
   if (!decimals) throw new Error('No decimals provided')
   return parseUnits(arg, decimals)
 }

--- a/tests/getDeploy/getDeploy.test.ts
+++ b/tests/getDeploy/getDeploy.test.ts
@@ -2,251 +2,85 @@ import { expect, describe, it } from 'bun:test'
 
 import { getTestConnectors } from '../getTestConnectors'
 import { getDeploy } from '../../src'
-import { RequestedModules } from '../../src/getDeploy/types'
-import { isAddress } from 'viem'
+import { Hex, isAddress } from 'viem'
 
-describe('#getDeploy', () => {
-  const { publicClient, walletClient } = getTestConnectors()
+// ===============CONSTANTS_START================
 
-  const USDC_SEPOLIA = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238' // USDC has 6 decimals
-  const mockAddress = '0x80f8493761a18d29fd77c131865f9cf62b15e62a' // self-deployed mock contract
-  const expectedBaseInputSchema = {
-    orchestrator: {
-      name: 'Orchestrator_v1',
-      inputs: [
-        {
-          name: 'owner',
-          type: 'address',
-          jsType: '0xstring',
-          description: 'The owner address of the workflow',
-        },
-        {
-          name: 'token',
-          type: 'address',
-          jsType: '0xstring',
-          description: 'The payment token associated with the workflow',
-        },
-      ],
-    },
-    fundingManager: {
-      name: 'FM_Rebasing_v1',
-      inputs: [
-        {
-          name: 'orchestratorTokenAddress',
-          type: 'address',
-          jsType: '0xstring',
-          description:
-            'The address of the token that will be deposited to the funding manager',
-        },
-      ],
-    },
-    authorizer: {
-      name: 'AUT_Roles_v1',
-      inputs: [
-        {
-          name: 'initialOwner',
-          type: 'address',
-          jsType: '0xstring',
-          description: 'The initial owner of the workflow',
-        },
-        {
-          name: 'initialManager',
-          type: 'address',
-          jsType: '0xstring',
-          description: 'The initial manager of the workflow',
-        },
-      ],
-    },
-    paymentProcessor: {
-      inputs: [],
-      name: 'PP_Simple_v1',
-    },
-  } as const
-
-  const args = {
-    orchestrator: {
-      owner: '0x5eb14c2e7D0cD925327d74ae4ce3fC692ff8ABEF',
-      token: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
-    },
-    fundingManager: {
-      orchestratorTokenAddress: '0x5eb14c2e7D0cD925327d74ae4ce3fC692ff8ABEF',
-    },
-    authorizer: {
-      initialOwner: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
-      initialManager: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
-    },
-  } as const
-
-  describe('Modules: FM_Rebasing_v1, AUT_Roles_v1, PP_Simple_v1', () => {
-    const requestedModules = {
-      fundingManager: 'FM_Rebasing_v1',
-      paymentProcessor: 'PP_Simple_v1',
-      authorizer: 'AUT_Roles_v1',
-    } satisfies RequestedModules
-
-    describe('optionalModules: none', () => {
-      describe('inputs', () => {
-        it('has the correct format', async () => {
-          const { inputs } = await getDeploy(
-            publicClient,
-            walletClient,
-            requestedModules
-          )
-          expect(inputs).toEqual({
-            ...expectedBaseInputSchema,
-          } as any)
-        })
-      })
-
-      describe.only('simulate', () => {
-        it('returns the orchestrator address as result', async () => {
-          const { simulate } = await getDeploy(
-            publicClient,
-            walletClient,
-            requestedModules
-          )
-          const simulationResult = await simulate(args)
-          expect(isAddress(simulationResult.result as string)).toBeTrue
-        })
-      })
-    })
-
-    describe('optional: LM_PC_Bounties_v1', () => {
-      describe('inputs', () => {
-        it('has the correct format', async () => {
-          const { inputs } = await getDeploy(publicClient, walletClient, {
-            ...requestedModules,
-            optionalModules: ['LM_PC_Bounties_v1'],
-          })
-
-          expect(inputs).toEqual({
-            ...expectedBaseInputSchema,
-            optionalModules: [
-              {
-                inputs: [],
-                name: 'LM_PC_Bounties_v1',
-              },
-            ],
-          })
-        })
-      })
-
-      describe('simulate', () => {
-        it('returns the orchestrator address as result', async () => {
-          const { simulate } = await getDeploy(publicClient, walletClient, {
-            ...requestedModules,
-            optionalModules: ['LM_PC_Bounties_v1'],
-          })
-          const simulationResult = await simulate(args)
-          expect(isAddress(simulationResult.result as string)).toBeTrue
-        })
-      })
-    })
-
-    describe('optional: LM_PC_RecurringPayments_v1', () => {
-      const expectedSchema = {
-        name: 'LM_PC_RecurringPayments_v1',
-        inputs: [
-          {
-            name: 'epochLength',
-            description:
-              'The length of an epoch in seconds. This will be the common denominator for all payments, as these are specified in epochs (i.e. if an epoch is 1 week, vestings can be done for 1 week, 2 week, 3 week, etc.). Epoch needs to be greater than 1 week and smaller than 52 weeks',
-            jsType: 'numberString',
-            type: 'uint256',
-          },
-        ],
-      }
-
-      describe('inputs', () => {
-        it('has the correct format', async () => {
-          const { inputs } = await getDeploy(publicClient, walletClient, {
-            ...requestedModules,
-            optionalModules: ['LM_PC_RecurringPayments_v1'],
-          } as any)
-
-          expect(inputs).toEqual({
-            ...expectedBaseInputSchema,
-            optionalModules: [expectedSchema],
-          } as any) // TODO: fix type to DeploySchema
-        })
-      })
-
-      describe('simulate', () => {
-        const epochLength = '604800' // 1 week in seconds
-
-        it('returns the orchestrator address as result', async () => {
-          const { simulate } = await getDeploy(publicClient, walletClient, {
-            ...requestedModules,
-            optionalModules: ['LM_PC_RecurringPayments_v1'],
-          } as any)
-          const simulationResult = await simulate({
-            ...args,
-            // @ts-expect-error: recurringPaymentManager is not in RequestedModules
-            optionalModules: {
-              LM_PC_RecurringPayments_v1: {
-                epochLength: BigInt(epochLength),
-              },
-            },
-          })
-          expect(isAddress(simulationResult.result as string)).toBeTrue
-        })
-      })
-    })
-  })
-
-  describe('Modules: FM_Rebasing_v1, AUT_TokenGated_Roles_v1, PP_Simple_v1', () => {
-    const requestedModules = {
-      fundingManager: 'FM_Rebasing_v1',
-      paymentProcessor: 'PP_Simple_v1',
-      authorizer: 'AUT_TokenGated_Roles_v1',
-    } satisfies RequestedModules
-
-    const expectedInputSchema = {
-      ...expectedBaseInputSchema,
-      authorizer: {
-        ...expectedBaseInputSchema.authorizer,
-        name: 'AUT_TokenGated_Roles_v1',
+const expectedBaseInputSchema = {
+  orchestrator: {
+    name: 'Orchestrator_v1',
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+        jsType: '0xstring',
+        description: 'The owner address of the workflow',
       },
-    }
+      {
+        name: 'token',
+        type: 'address',
+        jsType: '0xstring',
+        description: 'The payment token associated with the workflow',
+      },
+    ],
+  },
 
-    describe('optionalModules: none', () => {
-      describe('inputs', () => {
-        it('has the correct format', async () => {
-          const { inputs } = await getDeploy(
-            publicClient,
-            walletClient,
-            requestedModules
-          )
-          expect(inputs).toEqual({
-            ...expectedInputSchema,
-          } as any)
-        })
-      })
+  fundingManager: {
+    name: 'FM_Rebasing_v1',
+    inputs: [
+      {
+        name: 'orchestratorTokenAddress',
+        type: 'address',
+        jsType: '0xstring',
+        description:
+          'The address of the token that will be deposited to the funding manager',
+      },
+    ],
+  },
 
-      describe('simulate', () => {
-        it('returns the orchestrator address as result', async () => {
-          const { simulate } = await getDeploy(
-            publicClient,
-            walletClient,
-            requestedModules
-          )
-          const simulationResult = await simulate(args)
-          expect(isAddress(simulationResult.result as string)).toBeTrue
-        })
-      })
-    })
-  })
+  authorizer: {
+    name: 'AUT_Roles_v1',
+    inputs: [
+      {
+        name: 'initialOwner',
+        type: 'address',
+        jsType: '0xstring',
+        description: 'The initial owner of the workflow',
+      },
+      {
+        name: 'initialManager',
+        type: 'address',
+        jsType: '0xstring',
+        description: 'The initial manager of the workflow',
+      },
+    ],
+  },
 
-  describe('Modules: FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1, AUT_TokenGated_Roles_v1, PP_Simple_v1', () => {
-    const requestedModules = {
-      fundingManager: 'FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1',
-      paymentProcessor: 'PP_Simple_v1',
-      authorizer: 'AUT_Roles_v1',
-    } satisfies RequestedModules
+  paymentProcessor: {
+    inputs: [],
+    name: 'PP_Simple_v1',
+  },
+} as const
 
-    const expectedBCInputSchema = {
-      name: 'FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1',
-      inputs: [
+const baseArgs = {
+  orchestrator: {
+    owner: '0x5eb14c2e7D0cD925327d74ae4ce3fC692ff8ABEF',
+    token: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
+  },
+  fundingManager: {
+    orchestratorTokenAddress: '0x5eb14c2e7D0cD925327d74ae4ce3fC692ff8ABEF',
+  },
+  authorizer: {
+    initialOwner: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
+    initialManager: '0x7AcaF5360474b8E40f619770c7e8803cf3ED1053',
+  },
+} as const
+
+const expected_FM_BC_Restricted_BancorInputSchema = {
+  name: 'FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1',
+  inputs: [
+    {
+      components: [
         {
           name: 'name',
           type: 'string',
@@ -270,6 +104,18 @@ describe('#getDeploy', () => {
           tags: ['decimals:internal:exact:decimals'],
           jsType: 'numberString',
         },
+      ],
+      name: 'issuanceToken',
+      type: 'tuple',
+    },
+    {
+      name: 'tokenAdmin',
+      type: 'address',
+      description: 'The admin of the token',
+      jsType: '0xstring',
+    },
+    {
+      components: [
         {
           name: 'formula',
           type: 'address',
@@ -331,15 +177,189 @@ describe('#getDeploy', () => {
           tags: ['decimals:internal:indirect:acceptedToken'],
           jsType: 'numberString',
         },
-        {
-          name: 'acceptedToken',
-          type: 'address',
-          description:
-            'The address of the token that will be deposited to the funding manager',
-          jsType: '0xstring',
-        },
       ],
+      name: 'bondingCurveParams',
+      type: 'tuple',
+    },
+    {
+      name: 'acceptedToken',
+      type: 'address',
+      description:
+        'The address of the token that will be deposited to the funding manager',
+      jsType: '0xstring',
+    },
+  ],
+} as const
+
+// ===============CONSTANTS_END================
+
+describe('#getDeploy', () => {
+  const { publicClient, walletClient } = getTestConnectors()
+
+  const USDC_SEPOLIA = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238' as Hex // USDC has 6 decimals
+  const mockAddress = '0x80f8493761a18d29fd77c131865f9cf62b15e62a' as Hex // self-deployed mock contract
+
+  describe('Modules: FM_Rebasing_v1, AUT_Roles_v1, PP_Simple_v1', () => {
+    const requestedModules = {
+      fundingManager: 'FM_Rebasing_v1',
+      paymentProcessor: 'PP_Simple_v1',
+      authorizer: 'AUT_Roles_v1',
+    } as const
+
+    describe('optionalModules: none', () => {
+      describe('inputs', () => {
+        it('has the correct format', async () => {
+          const { inputs } = await getDeploy(
+            publicClient,
+            walletClient,
+            requestedModules
+          )
+
+          expect(inputs).toEqual(expectedBaseInputSchema)
+        })
+      })
+
+      describe.only('simulate', () => {
+        it('returns the orchestrator address as result', async () => {
+          const { simulate } = await getDeploy(
+            publicClient,
+            walletClient,
+            requestedModules
+          )
+          const simulationResult = await simulate(baseArgs)
+          expect(isAddress(simulationResult.result as string)).toBeTrue
+        })
+      })
+    })
+
+    describe('optional: LM_PC_Bounties_v1', () => {
+      describe('inputs', () => {
+        it('has the correct format', async () => {
+          const { inputs } = await getDeploy(publicClient, walletClient, {
+            ...requestedModules,
+            optionalModules: ['LM_PC_Bounties_v1'],
+          })
+
+          expect(inputs).toEqual({
+            ...expectedBaseInputSchema,
+            optionalModules: [
+              {
+                inputs: [],
+                name: 'LM_PC_Bounties_v1',
+              },
+            ],
+          })
+        })
+      })
+
+      describe('simulate', () => {
+        it('returns the orchestrator address as result', async () => {
+          const { simulate } = await getDeploy(publicClient, walletClient, {
+            ...requestedModules,
+            optionalModules: ['LM_PC_Bounties_v1'],
+          })
+          const simulationResult = await simulate(baseArgs)
+          expect(isAddress(simulationResult.result as string)).toBeTrue
+        })
+      })
+    })
+
+    describe('optional: LM_PC_RecurringPayments_v1', () => {
+      const expectedSchema = {
+        name: 'LM_PC_RecurringPayments_v1',
+        inputs: [
+          {
+            name: 'epochLength',
+            description:
+              'The length of an epoch in seconds. This will be the common denominator for all payments, as these are specified in epochs (i.e. if an epoch is 1 week, vestings can be done for 1 week, 2 week, 3 week, etc.). Epoch needs to be greater than 1 week and smaller than 52 weeks',
+            jsType: 'numberString',
+            type: 'uint256',
+          },
+        ],
+      } as const
+
+      describe('inputs', () => {
+        it('has the correct format', async () => {
+          const { inputs } = await getDeploy(publicClient, walletClient, {
+            ...requestedModules,
+            optionalModules: ['LM_PC_RecurringPayments_v1'],
+          })
+
+          expect(inputs).toEqual({
+            ...expectedBaseInputSchema,
+            optionalModules: [expectedSchema],
+          })
+        })
+      })
+
+      describe('simulate', () => {
+        it('returns the orchestrator address as result', async () => {
+          const { simulate } = await getDeploy(publicClient, walletClient, {
+            ...requestedModules,
+            optionalModules: ['LM_PC_RecurringPayments_v1'],
+          })
+
+          const simulationResult = await simulate({
+            ...baseArgs,
+            optionalModules: {
+              LM_PC_RecurringPayments_v1: {
+                epochLength: '604800', // 1 week in seconds,
+              },
+            },
+          })
+          expect(isAddress(simulationResult.result as string)).toBeTrue
+        })
+      })
+    })
+  })
+
+  describe('Modules: FM_Rebasing_v1, AUT_TokenGated_Roles_v1, PP_Simple_v1', () => {
+    const requestedModules = {
+      fundingManager: 'FM_Rebasing_v1',
+      paymentProcessor: 'PP_Simple_v1',
+      authorizer: 'AUT_TokenGated_Roles_v1',
+    } as const
+
+    const expectedInputSchema = {
+      ...expectedBaseInputSchema,
+      authorizer: {
+        ...expectedBaseInputSchema.authorizer,
+        name: 'AUT_TokenGated_Roles_v1' as const,
+      },
     }
+
+    describe('optionalModules: none', () => {
+      describe('inputs', () => {
+        it('has the correct format', async () => {
+          const { inputs } = await getDeploy(
+            publicClient,
+            walletClient,
+            requestedModules
+          )
+          expect(inputs).toEqual(expectedInputSchema)
+        })
+      })
+
+      describe('simulate', () => {
+        it('returns the orchestrator address as result', async () => {
+          const { simulate } = await getDeploy(
+            publicClient,
+            walletClient,
+            requestedModules
+          )
+          const simulationResult = await simulate(baseArgs)
+          expect(isAddress(simulationResult.result as string)).toBeTrue
+        })
+      })
+    })
+  })
+
+  describe('Modules: FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1, AUT_TokenGated_Roles_v1, PP_Simple_v1', () => {
+    const requestedModules = {
+      fundingManager: 'FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1',
+      paymentProcessor: 'PP_Simple_v1',
+      authorizer: 'AUT_Roles_v1',
+    } as const
 
     describe('inputs', () => {
       it('has the correct format', async () => {
@@ -350,28 +370,32 @@ describe('#getDeploy', () => {
         )
         expect(inputs).toEqual({
           ...expectedBaseInputSchema,
-          fundingManager: expectedBCInputSchema,
-        } as any)
+          fundingManager: expected_FM_BC_Restricted_BancorInputSchema,
+        })
       })
     })
 
     describe('simulate', () => {
       const bcArgs = {
-        name: 'Project Issuance Token',
-        symbol: 'QACC',
-        decimals: '18',
-        maxSupply: '115792',
+        issuanceToken: {
+          name: 'Project Issuance Token',
+          symbol: 'QACC',
+          decimals: '18',
+          maxSupply: '115792',
+        },
         tokenAdmin: mockAddress,
-        formula: mockAddress,
-        reserveRatioForBuying: '333333',
-        reserveRatioForSelling: '333333',
-        buyFee: '0',
-        sellFee: '100',
-        buyIsOpen: true,
-        sellIsOpen: false,
-        initialTokenSupply: '100',
-        initialCollateralSupply: '33',
-        acceptedToken: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238', //USDC
+        bondingCurveParams: {
+          formula: mockAddress,
+          reserveRatioForBuying: '333333',
+          reserveRatioForSelling: '333333',
+          buyFee: '0',
+          sellFee: '100',
+          buyIsOpen: true,
+          sellIsOpen: false,
+          initialTokenSupply: '100',
+          initialCollateralSupply: '33',
+        },
+        acceptedToken: USDC_SEPOLIA, //USDC
       }
 
       // it('has the correct format', async () => {
@@ -394,9 +418,9 @@ describe('#getDeploy', () => {
         )
 
         const simulationResult = await simulate({
-          ...args,
+          ...baseArgs,
           fundingManager: bcArgs,
-        } as any)
+        })
         expect(isAddress(simulationResult.result as string)).toBeTrue
       })
     })


### PR DESCRIPTION
- types were failing to resolve empty optional moduels ( fixed )
- encodeArgs had some redundant logic reduced
- added formatting to config data before passing to parse inputs
  - this makes sure the parser considers the jsType
- fixed the any types and as types in the getDeploy test

even though these were all done both tests regarding the deployments are failing mainly getValues is receiving an undefined value that is the first point of failiure

**Handover Notes**
after trying to halt before getValues realized that decimals is throwing an error `No Decimals Provided` I was not able to solve the issue before logging off.

- this commit takes care of many issues but is breaking the tests
- I encourage you to merge this im confident the solution is close here  
  -But I did not push the changes right away since both tests fail
   